### PR TITLE
Include plugin name with remote sync notification.

### DIFF
--- a/src/remote-sync.js
+++ b/src/remote-sync.js
@@ -17,7 +17,7 @@ module.exports = {
         }
 
         remoteSync.notify = (function (r) {
-            var notifyString = "Pushed master branch for " + pluginParams.name + " to the following repo locations (remote names): ";
+            var notifyString = "Pushed master branch for " + eeParams.name + " to the following repo locations (remote names): ";
             remotes.forEach(function (el) {
                 notifyString += ' ' + el;
             });

--- a/src/remote-sync.js
+++ b/src/remote-sync.js
@@ -17,7 +17,7 @@ module.exports = {
         }
 
         remoteSync.notify = (function (r) {
-            var notifyString = "Pushed master branch to the following repo locations (remote names): ";
+            var notifyString = "Pushed master branch for " + pluginParams.name + " to the following repo locations (remote names): ";
             remotes.forEach(function (el) {
                 notifyString += ' ' + el;
             });


### PR DESCRIPTION
Currently the notification would just do something like: 

> Pushed master branch to the following repo locations (remote names):  demoee

That provides no context with regards to what plugin was pushed.  So this pull adds the name of the plugin for that context.